### PR TITLE
Use `get-tsconfig` to parse a given tsconfig file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@mdn/browser-compat-data": "^4.0.0",
         "@web/dev-server-core": "^0.7.0",
         "esbuild": "^0.19.11",
+        "get-tsconfig": "^4.7.2",
         "parse5": "^6.0.1",
         "ua-parser-js": "^1.0.33"
       },
@@ -2322,6 +2323,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.2.tgz",
+      "integrity": "sha512-wuMsz4leaj5hbGgg4IvDU0bqJagpftG5l5cXIAvo8uZrqn0NJqwtfupTN00VnkQJPcIRrxYrm1Ue24btpCha2A==",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
@@ -3504,6 +3516,14 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
       "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
     },
     "node_modules/reusify": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@mdn/browser-compat-data": "^4.0.0",
     "@web/dev-server-core": "^0.7.0",
     "esbuild": "^0.19.11",
+    "get-tsconfig": "^4.7.2",
     "parse5": "^6.0.1",
     "ua-parser-js": "^1.0.33"
   },

--- a/src/EsbuildPlugin.ts
+++ b/src/EsbuildPlugin.ts
@@ -63,7 +63,7 @@ export class EsbuildPlugin implements Plugin {
     this.logger = logger;
     if (this.esbuildConfig.tsconfig) {
       const parsedTsconfig = await parseTsconfig(this.esbuildConfig.tsconfig);     
-      this.tsconfigRaw = parsedTsconfig ? JSON.stringify(parsedTsconfig) : await promisify(fs.readFile)(this.esbuildConfig.tsconfig, 'utf8');
+      this.tsconfigRaw = JSON.stringify(parsedTsconfig);
     }
   }
 

--- a/src/EsbuildPlugin.ts
+++ b/src/EsbuildPlugin.ts
@@ -18,6 +18,7 @@ import {
   setTextContent,
 } from '@web/dev-server-core/dist/dom5';
 import { parse as parseHtml, serialize as serializeHtml } from 'parse5';
+import { parseTsconfig } from 'get-tsconfig';
 
 import { getEsbuildTarget } from './getEsbuildTarget.js';
 
@@ -61,7 +62,8 @@ export class EsbuildPlugin implements Plugin {
     this.config = config;
     this.logger = logger;
     if (this.esbuildConfig.tsconfig) {
-      this.tsconfigRaw = await promisify(fs.readFile)(this.esbuildConfig.tsconfig, 'utf8');
+      const parsedTsconfig = await parseTsconfig(this.esbuildConfig.tsconfig);     
+      this.tsconfigRaw = parsedTsconfig ? JSON.stringify(parsedTsconfig) : await promisify(fs.readFile)(this.esbuildConfig.tsconfig, 'utf8');
     }
   }
 

--- a/src/EsbuildPlugin.ts
+++ b/src/EsbuildPlugin.ts
@@ -62,7 +62,7 @@ export class EsbuildPlugin implements Plugin {
     this.config = config;
     this.logger = logger;
     if (this.esbuildConfig.tsconfig) {
-      const parsedTsconfig = await parseTsconfig(this.esbuildConfig.tsconfig);     
+      const parsedTsconfig = await parseTsconfig(this.esbuildConfig.tsconfig);
       this.tsconfigRaw = JSON.stringify(parsedTsconfig);
     }
   }

--- a/test/fixture/tsconfig-with-experimental-decorators-parent.json
+++ b/test/fixture/tsconfig-with-experimental-decorators-parent.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./tsconfig-with-experimental-decorators.json"
+}

--- a/test/ts.test.ts
+++ b/test/ts.test.ts
@@ -123,7 +123,11 @@ class Bar {
         },
         esbuildPlugin({
           ts: true,
-          tsconfig: path.join(__dirname, 'fixture', 'tsconfig-with-experimental-decorators-parent.json'),
+          tsconfig: path.join(
+            __dirname,
+            'fixture',
+            'tsconfig-with-experimental-decorators-parent.json',
+          ),
         }),
       ],
     });

--- a/test/ts.test.ts
+++ b/test/ts.test.ts
@@ -104,6 +104,57 @@ class Bar {
     }
   });
 
+  it('transforms TS decorators with parent tsconfig', async () => {
+    const { server, host } = await createTestServer({
+      rootDir: __dirname,
+      plugins: [
+        {
+          name: 'test',
+          serve(context) {
+            if (context.path === '/foo.ts') {
+              return `
+@foo
+class Bar {
+  @prop
+  x = 'y';
+}`;
+            }
+          },
+        },
+        esbuildPlugin({
+          ts: true,
+          tsconfig: path.join(__dirname, 'fixture', 'tsconfig-with-experimental-decorators-parent.json'),
+        }),
+      ],
+    });
+
+    try {
+      const response = await fetch(`${host}/foo.ts`);
+      const text = await response.text();
+
+      expect(response.status).to.equal(200);
+      expect(response.headers.get('content-type')).to.equal(
+        'application/javascript; charset=utf-8',
+      );
+      expectIncludes(text, '__decorate');
+      expectIncludes(text, '__publicField(this, "x", "y");');
+      expectIncludes(
+        text,
+        `__decorateClass([
+  prop
+], Bar.prototype, "x", 2);`,
+      );
+      expectIncludes(
+        text,
+        `Bar = __decorateClass([
+  foo
+], Bar);`,
+      );
+    } finally {
+      server.stop();
+    }
+  });
+
   it('resolves relative ending with .js to .ts files', async () => {
     const { server, host } = await createTestServer({
       rootDir: path.join(__dirname, 'fixture'),


### PR DESCRIPTION
This PR fixes #20 by using `get-tsconfig`'s `parseTsconfig` method to return a fully resolved TS config.